### PR TITLE
Update prerequisites, Node.js v24 runtime, and community link

### DIFF
--- a/code/typescript/internal-constructs-workshop/construct-lib-repo/constructs/src/hitcounter.ts
+++ b/code/typescript/internal-constructs-workshop/construct-lib-repo/constructs/src/hitcounter.ts
@@ -27,7 +27,7 @@ export class HitCounter extends Construct {
     this.table = table;
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.fromAsset(props.hitcounterPath),
       environment: {

--- a/code/typescript/internal-constructs-workshop/construct-lib-repo/constructs/test/hitcounter.test.ts
+++ b/code/typescript/internal-constructs-workshop/construct-lib-repo/constructs/test/hitcounter.test.ts
@@ -9,7 +9,7 @@ test('DynamoDB Table Created', () => {
   new HitCounter(stack, 'MyTestConstruct', {
     hitcounterPath: 'lambda',
     downstream: new lambda.Function(stack, 'TestFunction', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'index.handler',
       code: lambda.Code.fromInline(`exports.handler = async function(event) {
           console.log("event: ", event);

--- a/code/typescript/internal-constructs-workshop/hello-cdk-app/lib/hello-cdk-app-stack.ts
+++ b/code/typescript/internal-constructs-workshop/hello-cdk-app/lib/hello-cdk-app-stack.ts
@@ -9,7 +9,7 @@ export class HelloCdkAppStack extends cdk.Stack {
 
     // this defines an AWS Lambda resource
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_16_X,    // execution environment
+      runtime: lambda.Runtime.NODEJS_24_X,    // execution environment
       code: lambda.Code.fromAsset('lambda'),  // code loaded from "lambda" directory
       handler: 'hello.handler'                // file is "hello", function is "handler"
     });

--- a/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
@@ -15,7 +15,7 @@ export class CdkWorkshopStack extends AwsStack {
 
     // defines an AWS Lambda resource
     const hello = new LambdaFunction(this, 'HelloHandler', {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       code: Code.fromAsset('lambda'),
       handler: 'hello.handler',
     });

--- a/code/typescript/main-workshop/lib/hitcounter.ts
+++ b/code/typescript/main-workshop/lib/hitcounter.ts
@@ -28,7 +28,7 @@ export class HitCounter extends Construct {
     this.table = table;
 
     this.handler = new LambdaFunction(this, 'HitCounterHandler', {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: 'hitcounter.handler',
       code: Code.fromAsset('lambda'),
       environment: {

--- a/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
@@ -13,7 +13,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       code: lambda.Code.fromAsset('lambda'),
       handler: 'hello.handler',
 

--- a/code/typescript/pipelines-workshop/lib/hitcounter.ts
+++ b/code/typescript/pipelines-workshop/lib/hitcounter.ts
@@ -33,7 +33,7 @@ export class HitCounter extends Construct {
     this.table = table;
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.fromAsset('lambda'),
       environment: {

--- a/code/typescript/tests-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/tests-workshop/lib/cdk-workshop-stack.ts
@@ -9,7 +9,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       code: lambda.Code.fromAsset('lambda'),
       handler: 'hello.handler',
 

--- a/code/typescript/tests-workshop/lib/hitcounter.ts
+++ b/code/typescript/tests-workshop/lib/hitcounter.ts
@@ -39,7 +39,7 @@ export class HitCounter extends Construct {
     this.table = table;
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.fromAsset('lambda'),
       environment: {

--- a/code/typescript/tests-workshop/test/hitcounter.test.ts
+++ b/code/typescript/tests-workshop/test/hitcounter.test.ts
@@ -8,7 +8,7 @@ test('DynamoDB Table Created', () => {
 
   new HitCounter(stack, 'MyTestConstruct', {
     downstream: new lambda.Function(stack, 'TestFunction', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'hello.handler',
       code: lambda.Code.fromAsset('lambda')
     })
@@ -24,7 +24,7 @@ test('Lambda Has Environment Variables', () => {
 
   new HitCounter(stack, 'MyTestConstruct', {
     downstream: new lambda.Function(stack, 'TestFunction', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'hello.handler',
       code: lambda.Code.fromAsset('lambda')
     })
@@ -55,7 +55,7 @@ test('DynamoDB Table Created With Encryption', () => {
 
   new HitCounter(stack, 'MyTestConstruct', {
     downstream: new lambda.Function(stack, 'TestFunction', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'hello.handler',
       code: lambda.Code.fromAsset('lambda')
     })
@@ -75,7 +75,7 @@ test('Read Capacity can be configured', () => {
   expect(() => {
     new HitCounter(stack, 'MyTestConstruct', {
       downstream: new lambda.Function(stack, 'TestFunction', {
-        runtime: lambda.Runtime.NODEJS_14_X,
+        runtime: lambda.Runtime.NODEJS_24_X,
         handler: 'hello.handler',
         code: lambda.Code.fromAsset('lambda')
       }),

--- a/workshop/config.toml
+++ b/workshop/config.toml
@@ -112,9 +112,9 @@ url = "https://stackoverflow.com/questions/tagged/terraconstructs"
 weight = 3
 
 [[menu.after]]
-name = "CDK on Discord"
+name = "CDK.dev Slack"
 identifier = "gt"
-url = "https://discord.gg/w2NNph9q9W"
+url = "https://cdk.dev"
 weight = 4
 
 [[menu.after]]

--- a/workshop/content/english/15-prerequisites/300-nodejs.md
+++ b/workshop/content/english/15-prerequisites/300-nodejs.md
@@ -5,7 +5,7 @@ weight = 300
 +++
 
 CDKTN uses Node.js (>= 20.9.0).
-A version in active long-term support (22.x at this writing) is recommended.
+A version in active long-term support (24.x at this writing) is recommended.
 
 * To install Node.js visit the [node.js](https://nodejs.org) website.
 
@@ -18,10 +18,10 @@ A version in active long-term support (22.x at this writing) is recommended.
     node --version
     ```
 
-    Output should be >= 18:
+    Output should be >= 20:
 
     ```
-    v20.19.3
+    v24.4.1
     ```
 
 {{< nextprevlinks >}}

--- a/workshop/content/english/15-prerequisites/_index.md
+++ b/workshop/content/english/15-prerequisites/_index.md
@@ -23,6 +23,6 @@ Click on the arrow to the right to continue to the first step.
 
 ## See Also
 
-- [Prerequisites in the CDKTN User Guide](https://cdktn.io/docs)
+- [Install CDKTN tutorial in the CDKTN User Guide](https://cdktn.io/docs/tutorials/install)
 
 {{< nextprevlinks >}}

--- a/workshop/content/english/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/english/20-typescript/30-hello-cdk/200-lambda.md
@@ -73,7 +73,7 @@ class MyStack extends AwsStack {
 
     // defines an AWS Lambda resource
     new LambdaFunction(this, "HelloHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       code: Code.fromAsset("lambda"),
       handler: "hello.handler",
     });
@@ -93,7 +93,7 @@ app.synth();
 
 A few things to notice:
 
-- Our function uses the NodeJS (`NODEJS_22_X`) runtime
+- Our function uses the NodeJS (`NODEJS_24_X`) runtime
 - The handler code is loaded from the `lambda` directory which we created
   earlier. Path is relative to where you execute `cdktn` from, which is the
   project's root directory

--- a/workshop/content/english/20-typescript/30-hello-cdk/400-apigw.md
+++ b/workshop/content/english/20-typescript/30-hello-cdk/400-apigw.md
@@ -36,7 +36,7 @@ class MyStack extends AwsStack {
 
     // defines an AWS Lambda resource
     const hello = new LambdaFunction(this, "HelloHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       code: Code.fromAsset("lambda"),
       handler: "hello.handler",
     });

--- a/workshop/content/english/20-typescript/40-hit-counter/300-resources.md
+++ b/workshop/content/english/20-typescript/40-hit-counter/300-resources.md
@@ -35,7 +35,7 @@ export class HitCounter extends Construct {
     });
 
     this.handler = new LambdaFunction(this, "HitCounterHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "hitcounter.handler",
       code: Code.fromAsset("lambda"),
       environment: {

--- a/workshop/content/english/20-typescript/40-hit-counter/400-use.md
+++ b/workshop/content/english/20-typescript/40-hit-counter/400-use.md
@@ -26,7 +26,7 @@ class MyStack extends AwsStack {
 
     // defines an AWS Lambda resource
     const hello = new LambdaFunction(this, "HelloHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       code: Code.fromAsset("lambda"),
       handler: "hello.handler",
     });

--- a/workshop/content/english/20-typescript/40-hit-counter/600-permissions.md
+++ b/workshop/content/english/20-typescript/40-hit-counter/600-permissions.md
@@ -36,7 +36,7 @@ export class HitCounter extends Construct {
     });
 
     this.handler = new LambdaFunction(this, "HitCounterHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "hitcounter.handler",
       code: Code.fromAsset("lambda"),
       environment: {
@@ -153,7 +153,7 @@ export class HitCounter extends Construct {
     });
 
     this.handler = new LambdaFunction(this, "HitCounterHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "hitcounter.handler",
       code: Code.fromAsset("lambda"),
       environment: {

--- a/workshop/content/english/20-typescript/50-table-viewer/300-add.md
+++ b/workshop/content/english/20-typescript/50-table-viewer/300-add.md
@@ -28,7 +28,7 @@ class MyStack extends AwsStack {
 
     // defines an AWS Lambda resource
     const hello = new LambdaFunction(this, "HelloHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       code: Code.fromAsset("lambda"),
       handler: "hello.handler",
     });

--- a/workshop/content/english/20-typescript/50-table-viewer/400-expose-table.md
+++ b/workshop/content/english/20-typescript/50-table-viewer/400-expose-table.md
@@ -38,7 +38,7 @@ export class HitCounter extends Construct {
     this.table = table;
 
     this.handler = new LambdaFunction(this, "HitCounterHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "hitcounter.handler",
       code: Code.fromAsset("lambda"),
       environment: {
@@ -78,7 +78,7 @@ class MyStack extends AwsStack {
 
     // defines an AWS Lambda resource
     const hello = new LambdaFunction(this, "HelloHandler", {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       code: Code.fromAsset("lambda"),
       handler: "hello.handler",
     });

--- a/workshop/content/english/20-typescript/60-cleanups/_index.md
+++ b/workshop/content/english/20-typescript/60-cleanups/_index.md
@@ -55,7 +55,7 @@ export class HitCounter extends Construct {
     this.table = table;
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.fromAsset('lambda'),
       environment: {

--- a/workshop/content/english/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/english/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -56,7 +56,7 @@ describe("HitCounter", () => {
     // WHEN
     new HitCounter(stack, "MyTestConstruct", {
       downstream: new LambdaFunction(stack, "TestFunction", {
-        runtime: Runtime.NODEJS_20_X,
+        runtime: Runtime.NODEJS_24_X,
         handler: "hello.handler",
         code: Code.fromAsset("lambda"),
       }),
@@ -113,7 +113,7 @@ environment variable values were references to other constructs.
 
 {{<highlight ts "hl_lines=6-7">}}
 this.handler = new lambda.Function(this, 'HitCounterHandler', {
-  runtime: lambda.Runtime.NODEJS_20_X,
+  runtime: lambda.Runtime.NODEJS_24_X,
   handler: 'hitcounter.handler',
   code: lambda.Code.fromAsset('lambda'),
   environment: {
@@ -140,7 +140,7 @@ Create a new test in `hitcounter.test.ts` with the below code:
     // WHEN
     new HitCounter(stack, 'MyTestConstruct', {
       downstream:  new LambdaFunction(stack, 'TestFunction', {
-        runtime: Runtime.NODEJS_20_X,
+        runtime: Runtime.NODEJS_24_X,
         handler: 'hello.handler',
         code: Code.fromAsset('lambda')
       })
@@ -224,7 +224,7 @@ Grab the real values for the environment variables and update your test
     // WHEN
     new HitCounter(stack, 'MyTestConstruct', {
       downstream:  new LambdaFunction(stack, 'TestFunction', {
-        runtime: Runtime.NODEJS_20_X,
+        runtime: Runtime.NODEJS_24_X,
         handler: 'hello.handler',
         code: Code.fromAsset('lambda')
       })
@@ -280,7 +280,7 @@ First we'll update the test to reflect this new requirement.
     // WHEN
     new HitCounter(stack, "MyTestConstruct", {
       downstream: new LambdaFunction(stack, "TestFunction", {
-        runtime: Runtime.NODEJS_20_X,
+        runtime: Runtime.NODEJS_24_X,
         handler: "hello.handler",
         code: Code.fromAsset("lambda"),
       }),
@@ -381,7 +381,7 @@ export class HitCounter extends Construct {
     });
 
     this.handler = new LambdaFunction(this, "HitCounterHandler", {
-      runtime: Runtime.NODEJS_20_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "hitcounter.handler",
       code: Code.fromAsset("lambda"),
       environment: {


### PR DESCRIPTION
Resolves #78

- Point the prerequisites "See Also" link to the CDKTN install tutorial
- State Node.js v24 as the active LTS on the Node.js prerequisites page
- Bump all TypeScript Lambda runtime snippets to Runtime.NODEJS_24_X
  across the Hello CDK, API Gateway, Hit Counter, Table Viewer,
  construct-testing, and cleanups lessons
- Switch the community menu link from Discord to the CDK.dev Slack

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ppt52CZbgtFJS5FjevDzGe